### PR TITLE
Enable time offset

### DIFF
--- a/src/utils/MessageCreator.cpp
+++ b/src/utils/MessageCreator.cpp
@@ -58,9 +58,7 @@ MessageCreator::createLaserScanMsg(const sick::datastructure::Data& data, rclcpp
 {
   sensor_msgs::msg::LaserScan scan;
   scan.header.frame_id = m_frame_id;
-  scan.header.stamp    = now;
-  // Add time offset (to account for network latency etc.)
-  // scan.header.stamp += ros::Duration().fromSec(m_time_offset); TODO
+  scan.header.stamp    = now + rclcpp::Duration::from_seconds(m_time_offset);
   // TODO check why returned number of beams is misaligned to size of vector
   std::vector<sick::datastructure::ScanPoint> scan_points =
     data.getMeasurementDataPtr()->getScanPointsVector();


### PR DESCRIPTION
Hello,

We are currently using several Nanoscan3 safety lidars on AGVs on ROS2 Galactic.
To make the lidar time stamp fit the robot motion, I implemented the time offset of the stamp.

It was a TODO, I just migrated the implementation from ROS1 to ROS2.