### PR TITLE
Implement lifecycle node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,16 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(Boost REQUIRED COMPONENTS chrono)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(sick_safetyscanners_base REQUIRED)
 find_package(sick_safetyscanners2_interfaces REQUIRED)
 
 set(dependencies
   rclcpp
+  rclcpp_lifecycle 
+  lifecycle_msgs 
   sensor_msgs
   sick_safetyscanners_base
   sick_safetyscanners2_interfaces
@@ -45,12 +49,31 @@ target_include_directories(sick_safetyscanners2_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
+  add_executable(sick_safetyscanners2_lifecycle_node 
+  src/sick_safetyscanners2_lifecycle_node.cpp
+  src/SickSafetyscannersLifeCycle.cpp
+  src/utils/MessageCreator.cpp)
+
+target_link_libraries(sick_safetyscanners2_lifecycle_node 
+  sick_safetyscanners_base::sick_safetyscanners_base
+  ${Boost_LIBRARIES})
+
+ament_target_dependencies(sick_safetyscanners2_lifecycle_node ${dependencies})
+
+target_include_directories(sick_safetyscanners2_lifecycle_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
 install(DIRECTORY
 launch
 DESTINATION share/${PROJECT_NAME}/
 )
 
 install(TARGETS sick_safetyscanners2_node
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS sick_safetyscanners2_lifecycle_node
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
 

--- a/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
@@ -1,0 +1,139 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2020, SICK AG, Waldkirch
+*  Copyright (C) 2020, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file SickSafetyscannersLifeCycle.hpp
+ *
+ * \authors  Soma gallai<soma.gallai@cm-robotics.com>  Erwin Lejeune <erwin.lejeune@cm-robotics.com>
+ * \date    2021-05-27
+ */
+//----------------------------------------------------------------------
+
+#ifndef SICK_SAFETYSCANNERS2_SICKSAFETYSCANNERSLIFECYCLE_H
+#define SICK_SAFETYSCANNERS2_SICKSAFETYSCANNERSLIFECYCLE_H
+
+#include <sick_safetyscanners_base/SickSafetyscanners.h>
+#include <sick_safetyscanners_base/Types.h>
+#include <sick_safetyscanners_base/datastructure/Data.h>
+
+#include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
+#include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
+#include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
+
+#include <sick_safetyscanners2/utils/Conversions.h>
+#include <sick_safetyscanners2/utils/MessageCreator.h>
+
+#include <lifecycle_msgs/msg/transition.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <lifecycle_msgs/srv/change_state.hpp>
+#include <lifecycle_msgs/srv/get_state.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <rclcpp_lifecycle/lifecycle_publisher.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+#include <string>
+
+namespace sick {
+
+class SickSafetyscannersLifeCycle : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  /*!
+   * \brief Constructor of the ROS2 Node handling the Communication of the Sick Safetyscanner
+   */
+
+  explicit SickSafetyscannersLifeCycle (const std::string & node_name, bool intra_process_comms = false);
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure (const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate (const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate (const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup (const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown (const rclcpp_lifecycle::State &);
+
+private:
+  // Publishers
+  rclcpp_lifecycle::LifecyclePublisher<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>::SharedPtr
+    m_extended_laser_scan_publisher;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr m_laser_scan_publisher;
+  rclcpp_lifecycle::LifecyclePublisher<sick_safetyscanners2_interfaces::msg::OutputPaths>::SharedPtr
+    m_output_paths_publisher;
+  rclcpp_lifecycle::LifecyclePublisher<sick_safetyscanners2_interfaces::msg::RawMicroScanData>::SharedPtr
+    m_raw_data_publisher;
+
+  // Services
+  rclcpp::Service<sick_safetyscanners2_interfaces::srv::FieldData>::SharedPtr m_field_data_service;
+  // Parameters
+  OnSetParametersCallbackHandle::SharedPtr m_param_callback;
+  rcl_interfaces::msg::SetParametersResult
+  parametersCallback(std::vector<rclcpp::Parameter> parameters);
+
+
+  // Device and Communication
+  std::unique_ptr<sick::AsyncSickSafetyScanner> m_device;
+  sick::datastructure::CommSettings m_communications_settings;
+
+  // Helper for Message Generation
+  std::unique_ptr<sick::MessageCreator> m_msg_creator;
+
+  // General Variables
+  boost::asio::ip::address_v4 m_sensor_ip;
+  boost::asio::ip::address_v4 m_interface_ip;
+  std::string m_frame_id;
+  double m_time_offset;
+  double m_range_min;
+  double m_range_max;
+  double m_frequency_tolerance      = 0.1;
+  double m_expected_frequency       = 20.0;
+  double m_timestamp_min_acceptable = -1.0;
+  double m_timestamp_max_acceptable = 1.0;
+  double m_min_intensities          = 0.0; /*!< min intensities for laser points */
+  bool m_use_sick_angles;
+  float m_angle_offset;
+  bool m_use_pers_conf;
+
+  // TODO diagnostics?
+  // TODO dynamic reconfigure?
+
+  // Methods for ROS2 parameter handling
+  void initialize_parameters();
+  void load_parameters();
+  void onParameterEventCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+
+  // Callback function passed to the device for handling the received packages
+  void receiveUDPPaket(const sick::datastructure::Data& data);
+
+  // Methods Triggering COLA2 calls towards the sensor
+  bool getFieldData(
+    const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,
+    std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Response> response);
+  void readPersistentConfig();
+  void readTypeCodeSettings();
+};
+} // namespace sick
+
+#endif // SICK_SAFETYSCANNERS2_SICKSAFETYSCANNERSLIFECYCLE_H

--- a/launch/sick_safetyscanners2_lifecycle_launch.py
+++ b/launch/sick_safetyscanners2_lifecycle_launch.py
@@ -1,0 +1,33 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package="sick_safetyscanners2",
+            executable="sick_safetyscanners2_lifecycle_node",
+            name="sick_safetyscanners2_lifecycle_node",
+            output="screen",
+            emulate_tty=True,
+            parameters=[
+                {"frame_id": "scan",
+                 "sensor_ip": "192.168.1.11",
+                 "host_ip": "192.168.1.9",
+                 "interface_ip": "0.0.0.0",
+                 "host_udp_port": 0,
+                 "channel": 0,
+                 "channel_enabled": True,
+                 "skip": 0,
+                 "angle_start": 0.0,
+                 "angle_end": 0.0,
+                 "time_offset": 0.0,
+                 "general_system_state": True,
+                 "derived_settings": True,
+                 "measurement_data": True,
+                 "intrusion_data": True,
+                 "application_io_data": True,
+                 "use_persistent_config": False,
+                 "min_intensities": 0.0}
+            ]
+        )
+    ])

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   
   <depend>boost</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
   <depend>sick_safetyscanners_base</depend>
   <depend>sick_safetyscanners2_interfaces</depend>

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -106,12 +106,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
     readPersistentConfig();
   }
 
-  // Start async receiving and processing of sensor data
-  m_device->run();
-  m_device->changeSensorSettings(m_communications_settings);
-  m_msg_creator = std::make_unique<sick::MessageCreator>(
-    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
-  RCLCPP_INFO(this->get_logger(), "Node Configured and running"); 
+  RCLCPP_INFO(this->get_logger(), "Node Configured"); 
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
@@ -119,20 +114,30 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_activate()...");
+  // Start async receiving and processing of sensor data
+  m_device->run();
+  m_device->changeSensorSettings(m_communications_settings);
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
   m_laser_scan_publisher->on_activate();
   m_extended_laser_scan_publisher->on_activate();
   m_output_paths_publisher->on_activate();
   m_raw_data_publisher->on_activate();
+
+  RCLCPP_INFO(this->get_logger(), "Node activated, device is running...");
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_deactivate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_deactivate()...");
+  m_device->stop();
   m_laser_scan_publisher->on_deactivate();
   m_extended_laser_scan_publisher->on_deactivate();
   m_output_paths_publisher->on_deactivate();
   m_raw_data_publisher->on_deactivate();
+
+  RCLCPP_INFO(this->get_logger(), "Node deactivated, device stopped...");
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -1,0 +1,518 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2020, SICK AG, Waldkirch
+*  Copyright (C) 2020, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file SickSafetyscannersLifeCycle.cpp
+ *
+ * \authors  Soma gallai<soma.gallai@cm-robotics.com>  Erwin Lejeune <erwin.lejeune@cm-robotics.com>
+ * \date    2021-05-27
+ */
+//----------------------------------------------------------------------
+
+#include <sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp>
+
+namespace sick {
+
+
+SickSafetyscannersLifeCycle::SickSafetyscannersLifeCycle (const std::string & node_name, bool intra_process_comms)
+  : rclcpp_lifecycle::LifecycleNode(node_name, rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms))
+  , m_time_offset(0.0)
+  , m_range_min(0.0)
+  , m_range_max(0.0)
+  , m_angle_offset(-90.0)
+  , m_use_pers_conf(false)
+{
+  RCLCPP_INFO(this->get_logger(), "Initializing SickSafetyscannersLifeCycle ");
+
+  // read parameters!
+  initialize_parameters();
+  load_parameters();
+  
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State &)
+{
+ RCLCPP_INFO(this->get_logger(), "on_configure()...");
+ sick::types::port_t tcp_port{2122};
+
+  // Dynamic Parameter Change client
+  m_param_callback = add_on_set_parameters_callback(
+    std::bind(&SickSafetyscannersLifeCycle::parametersCallback, this, std::placeholders::_1));
+
+  // TODO reconfigure?
+  // TODO diagnostics
+
+  // init publishers and services
+  m_laser_scan_publisher = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", 1);
+  m_extended_laser_scan_publisher =
+    this->create_publisher<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>("extended_scan",
+                                                                                    1);
+  m_output_paths_publisher =
+    this->create_publisher<sick_safetyscanners2_interfaces::msg::OutputPaths>("output_paths", 1);
+  m_raw_data_publisher =
+    this->create_publisher<sick_safetyscanners2_interfaces::msg::RawMicroScanData>("raw_data", 1);
+
+  m_field_data_service = this->create_service<sick_safetyscanners2_interfaces::srv::FieldData>(
+    "field_data",
+    std::bind(
+      &SickSafetyscannersLifeCycle::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
+
+  // Bind callback
+  std::function<void(const sick::datastructure::Data&)> callback =
+    std::bind(&SickSafetyscannersLifeCycle::receiveUDPPaket, this, std::placeholders::_1);
+
+  // Create a sensor instance
+  if (m_communications_settings.host_ip.is_multicast())
+  {
+    m_device = std::make_unique<sick::AsyncSickSafetyScanner>(
+      m_sensor_ip, tcp_port, m_communications_settings, m_interface_ip, callback);
+  }
+  else
+  {
+    m_device = std::make_unique<sick::AsyncSickSafetyScanner>(
+      m_sensor_ip, tcp_port, m_communications_settings, callback);
+  }
+
+  RCLCPP_INFO(this->get_logger(), "Communication to Sensor set up");
+
+  // Read sensor specific configurations
+  readTypeCodeSettings();
+
+  if (m_use_pers_conf)
+  {
+    readPersistentConfig();
+  }
+
+  // Start async receiving and processing of sensor data
+  m_device->run();
+  m_device->changeSensorSettings(m_communications_settings);
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
+  RCLCPP_INFO(this->get_logger(), "Node Configured and running"); 
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_activate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_activate()...");
+  m_laser_scan_publisher->on_activate();
+  m_extended_laser_scan_publisher->on_activate();
+  m_output_paths_publisher->on_activate();
+  m_raw_data_publisher->on_activate();
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_deactivate()...");
+  m_laser_scan_publisher->on_deactivate();
+  m_extended_laser_scan_publisher->on_deactivate();
+  m_output_paths_publisher->on_deactivate();
+  m_raw_data_publisher->on_deactivate();
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_cleanup (const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_cleanup()...");
+  m_laser_scan_publisher.reset();
+  m_extended_laser_scan_publisher.reset();
+  m_output_paths_publisher.reset();
+  m_raw_data_publisher.reset();
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSafetyscannersLifeCycle::on_shutdown (const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_shutdown()...");
+  m_laser_scan_publisher.reset();
+  m_extended_laser_scan_publisher.reset();
+  m_output_paths_publisher.reset();
+  m_raw_data_publisher.reset();
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+void SickSafetyscannersLifeCycle::readTypeCodeSettings()
+{
+  RCLCPP_INFO(this->get_logger(), "Reading Type code settings");
+  sick::datastructure::TypeCode type_code;
+  m_device->requestTypeCode(type_code);
+  m_communications_settings.e_interface_type = type_code.getInterfaceType();
+  m_range_min                                = 0.1;
+  m_range_max                                = type_code.getMaxRange();
+}
+
+void SickSafetyscannersLifeCycle::readPersistentConfig()
+{
+  RCLCPP_INFO(this->get_logger(), "Reading Persistent Configuration");
+  sick::datastructure::ConfigData config_data;
+  m_device->requestPersistentConfig(config_data);
+  m_communications_settings.start_angle = config_data.getStartAngle();
+  m_communications_settings.end_angle   = config_data.getEndAngle();
+}
+
+void SickSafetyscannersLifeCycle::initialize_parameters()
+{
+  this->declare_parameter<std::string>("frame_id", "scan");
+  this->declare_parameter<std::string>("sensor_ip", "192.168.1.11");
+  this->declare_parameter<std::string>("host_ip", "192.168.1.9");
+  this->declare_parameter<std::string>("interface_ip", "0.0.0.0");
+  this->declare_parameter<int>("host_udp_port", 0);
+  this->declare_parameter<int>("channel", 0);
+  this->declare_parameter<bool>("channel_enabled", true);
+  this->declare_parameter<int>("skip", 0);
+  this->declare_parameter<double>("angle_start", 0.0);
+  this->declare_parameter<double>("angle_end", 0.0);
+  this->declare_parameter<double>("time_offset", 0.0); // TODO
+  this->declare_parameter<bool>("general_system_state", true);
+  this->declare_parameter<bool>("derived_settings", true);
+  this->declare_parameter<bool>("measurement_data", true);
+  this->declare_parameter<bool>("intrusion_data", true);
+  this->declare_parameter<bool>("application_io_data", true);
+  this->declare_parameter<bool>("use_persistent_config", false);
+  this->declare_parameter<float>("min_intensities", 0.f);
+}
+
+void SickSafetyscannersLifeCycle::load_parameters()
+{
+  rclcpp::Logger node_logger = this->get_logger();
+
+  this->get_parameter<std::string>("frame_id", m_frame_id);
+  RCLCPP_INFO(node_logger, "frame_id: %s", m_frame_id.c_str());
+
+  std::string sensor_ip;
+  this->get_parameter<std::string>("sensor_ip", sensor_ip);
+  RCLCPP_INFO(node_logger, "sensor_ip: %s", sensor_ip.c_str());
+  m_sensor_ip = boost::asio::ip::address_v4::from_string(sensor_ip);
+
+  std::string interface_ip;
+  this->get_parameter<std::string>("interface_ip", interface_ip);
+  RCLCPP_INFO(node_logger, "interface_ip: %s", interface_ip.c_str());
+  m_interface_ip = boost::asio::ip::address_v4::from_string(interface_ip);
+
+  std::string host_ip;
+  this->get_parameter<std::string>("host_ip", host_ip);
+  RCLCPP_INFO(node_logger, "host_ip: %s", host_ip.c_str());
+  // TODO check if valid IP?
+  m_communications_settings.host_ip = boost::asio::ip::address_v4::from_string(host_ip);
+
+  int host_udp_port;
+  this->get_parameter<int>("host_udp_port", host_udp_port);
+  RCLCPP_INFO(node_logger, "host_udp_port: %i", host_udp_port);
+  m_communications_settings.host_udp_port = host_udp_port;
+
+  int channel;
+  this->get_parameter<int>("channel", channel);
+  RCLCPP_INFO(node_logger, "channel: %i", channel);
+  m_communications_settings.channel = channel;
+
+  bool enabled;
+  this->get_parameter<bool>("channel_enabled", enabled);
+  RCLCPP_INFO(node_logger, "channel_enabled: %s", btoa(enabled).c_str());
+  m_communications_settings.enabled = enabled;
+
+  int skip;
+  this->get_parameter<int>("skip", skip);
+  RCLCPP_INFO(node_logger, "skip: %i", skip);
+  m_communications_settings.publishing_frequency = skipToPublishFrequency(skip);
+
+  float angle_start;
+  this->get_parameter<float>("angle_start", angle_start);
+  RCLCPP_INFO(node_logger, "angle_start: %f", angle_start);
+
+  float angle_end;
+  this->get_parameter<float>("angle_end", angle_end);
+  RCLCPP_INFO(node_logger, "angle_end: %f", angle_end);
+
+  // Included check before calculations to prevent rounding errors while calculating
+  if (angle_start == angle_end)
+  {
+    m_communications_settings.start_angle = sick::radToDeg(0);
+    m_communications_settings.end_angle   = sick::radToDeg(0);
+  }
+  else
+  {
+    m_communications_settings.start_angle = sick::radToDeg(angle_start) - m_angle_offset;
+    m_communications_settings.end_angle   = sick::radToDeg(angle_end) - m_angle_offset;
+  }
+
+
+  this->get_parameter<double>("time_offset", m_time_offset);
+  RCLCPP_INFO(node_logger, "time_offset: %f", m_time_offset);
+
+  // Features
+  bool general_system_state;
+  this->get_parameter<bool>("general_system_state", general_system_state);
+  RCLCPP_INFO(node_logger, "general_system_state: %s", btoa(general_system_state).c_str());
+
+  bool derived_settings;
+  this->get_parameter<bool>("derived_settings", derived_settings);
+  RCLCPP_INFO(node_logger, "derived_settings: %s", btoa(derived_settings).c_str());
+
+  bool measurement_data;
+  this->get_parameter<bool>("measurement_data", measurement_data);
+  RCLCPP_INFO(node_logger, "measurement_data: %s", btoa(measurement_data).c_str());
+
+  bool intrusion_data;
+  this->get_parameter<bool>("intrusion_data", intrusion_data);
+  RCLCPP_INFO(node_logger, "intrusion_data: %s", btoa(intrusion_data).c_str());
+
+  bool application_io_data;
+  this->get_parameter<bool>("application_io_data", application_io_data);
+  RCLCPP_INFO(node_logger, "application_io_data: %s", btoa(application_io_data).c_str());
+
+  m_communications_settings.features = sick::SensorDataFeatures::toFeatureFlags(
+    general_system_state, derived_settings, measurement_data, intrusion_data, application_io_data);
+
+
+  this->get_parameter<bool>("use_persistent_config", m_use_pers_conf);
+  RCLCPP_INFO(node_logger, "use_persistent_config: %s", btoa(m_use_pers_conf).c_str());
+
+  this->get_parameter<double>("min_intensities", m_min_intensities);
+  RCLCPP_INFO(node_logger, "min_intensities: %f", m_min_intensities);
+}
+
+rcl_interfaces::msg::SetParametersResult
+SickSafetyscannersLifeCycle::parametersCallback(std::vector<rclcpp::Parameter> parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful         = true;
+  result.reason             = "";
+  bool update_sensor_config = false;
+
+  for (auto param : parameters)
+  {
+    {
+      std::stringstream ss;
+      ss << "{" << param.get_name() << ", " << param.value_to_string() << "}";
+      RCLCPP_INFO(this->get_logger(), "Got parameter: '%s'", ss.str().c_str());
+
+      if (!param.get_name().compare("frame_id"))
+      {
+        m_frame_id = param.value_to_string();
+      }
+      else if (!param.get_name().compare("host_ip"))
+      {
+        m_communications_settings.host_ip =
+          boost::asio::ip::address_v4::from_string(param.value_to_string());
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("host_udp_port"))
+      {
+        m_communications_settings.host_udp_port = param.as_int();
+        update_sensor_config                    = true;
+      }
+      else if (!param.get_name().compare("channel"))
+      {
+        m_communications_settings.channel = param.as_int();
+        update_sensor_config              = true;
+      }
+      else if (!param.get_name().compare("channel_enabled"))
+      {
+        m_communications_settings.enabled = param.as_bool();
+        update_sensor_config              = true;
+      }
+      else if (!param.get_name().compare("skip"))
+      {
+        m_communications_settings.publishing_frequency = skipToPublishFrequency(param.as_int());
+        update_sensor_config                           = true;
+      }
+      else if (!param.get_name().compare("angle_start"))
+      {
+        // TODO cleanup
+        double angle_start = param.as_double();
+        double angle_end;
+        this->get_parameter<double>("angle_end", angle_end);
+        if (angle_start == angle_end)
+        {
+          m_communications_settings.start_angle = sick::radToDeg(0);
+          m_communications_settings.end_angle   = sick::radToDeg(0);
+        }
+        else
+        {
+          m_communications_settings.start_angle = sick::radToDeg(angle_start) - m_angle_offset;
+          m_communications_settings.end_angle   = sick::radToDeg(angle_end) - m_angle_offset;
+        }
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("angle_end"))
+      {
+        // TODO cleanup
+        double angle_end = param.as_double();
+        double angle_start;
+        this->get_parameter<double>("angle_start", angle_start);
+        if (angle_start == angle_end)
+        {
+          m_communications_settings.start_angle = sick::radToDeg(0);
+          m_communications_settings.end_angle   = sick::radToDeg(0);
+        }
+        else
+        {
+          m_communications_settings.start_angle = sick::radToDeg(angle_start) - m_angle_offset;
+          m_communications_settings.end_angle   = sick::radToDeg(angle_end) - m_angle_offset;
+        }
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("time_offset"))
+      {
+        m_time_offset = param.as_double();
+      }
+      else if (!param.get_name().compare("general_system_state"))
+      {
+        // TODO improve
+        m_communications_settings.features =
+          (m_communications_settings.features & ~(1UL << 0)) | (param.as_bool() << 0);
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("derived_settings"))
+      {
+        m_communications_settings.features =
+          (m_communications_settings.features & ~(1UL << 1)) | (param.as_bool() << 1);
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("measurement_data"))
+      {
+        m_communications_settings.features =
+          (m_communications_settings.features & ~(1UL << 2)) | (param.as_bool() << 2);
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("intrusion_data"))
+      {
+        m_communications_settings.features =
+          (m_communications_settings.features & ~(1UL << 3)) | (param.as_bool() << 3);
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("application_io_data"))
+      {
+        m_communications_settings.features =
+          (m_communications_settings.features & ~(1UL << 4)) | (param.as_bool() << 4);
+        update_sensor_config = true;
+      }
+      else if (!param.get_name().compare("min_intensities"))
+      {
+        m_min_intensities = param.as_double();
+      }
+      else
+      {
+        result.successful = false;
+        result.reason     = "Parameter is not dynamic reconfigurable";
+        RCLCPP_WARN(this->get_logger(),
+                    "Parameter %s not dynamically reconfigurable",
+                    param.get_name().c_str());
+      }
+    }
+  }
+  if (update_sensor_config)
+  {
+    m_device->changeSensorSettings(m_communications_settings);
+  }
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
+  return result;
+}
+
+
+void SickSafetyscannersLifeCycle::receiveUDPPaket(const sick::datastructure::Data& data)
+{
+  if (!data.getMeasurementDataPtr()->isEmpty() && !data.getDerivedValuesPtr()->isEmpty())
+  {
+    auto scan = m_msg_creator->createLaserScanMsg(data, this->now());
+    m_laser_scan_publisher->publish(scan);
+
+    sick_safetyscanners2_interfaces::msg::ExtendedLaserScan extended_scan =
+      m_msg_creator->createExtendedLaserScanMsg(data, this->now());
+
+    m_extended_laser_scan_publisher->publish(extended_scan);
+
+    auto output_paths = m_msg_creator->createOutputPathsMsg(data);
+    m_output_paths_publisher->publish(output_paths);
+  }
+
+  auto raw_msg = m_msg_creator->createRawDataMsg(data);
+  m_raw_data_publisher->publish(raw_msg);
+}
+
+
+bool SickSafetyscannersLifeCycle::getFieldData(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  std::vector<sick::datastructure::FieldData> fields;
+  m_device->requestFieldData(fields);
+
+  for (size_t i = 0; i < fields.size(); i++)
+  {
+    sick::datastructure::FieldData field = fields.at(i);
+    sick_safetyscanners2_interfaces::msg::Field field_msg;
+
+    field_msg.start_angle        = degToRad(field.getStartAngle() + m_angle_offset);
+    field_msg.angular_resolution = degToRad(field.getAngularBeamResolution());
+    field_msg.protective_field   = field.getIsProtectiveField();
+
+    std::vector<uint16_t> ranges = field.getBeamDistances();
+    for (size_t j = 0; j < ranges.size(); j++)
+    {
+      field_msg.ranges.push_back(static_cast<float>(ranges.at(j)) * 1e-3);
+    }
+
+    response->fields.push_back(field_msg);
+  }
+
+  datastructure::DeviceName device_name;
+  m_device->requestDeviceName(device_name);
+  response->device_name = device_name.getDeviceName();
+
+
+  std::vector<sick::datastructure::MonitoringCaseData> monitoring_cases;
+  m_device->requestMonitoringCases(monitoring_cases);
+
+  for (size_t i = 0; i < monitoring_cases.size(); i++)
+  {
+    sick::datastructure::MonitoringCaseData monitoring_case_data = monitoring_cases.at(i);
+    sick_safetyscanners2_interfaces::msg::MonitoringCase monitoring_case_msg;
+
+    monitoring_case_msg.monitoring_case_number = monitoring_case_data.getMonitoringCaseNumber();
+    std::vector<uint16_t> mon_fields           = monitoring_case_data.getFieldIndices();
+    std::vector<bool> mon_fields_valid         = monitoring_case_data.getFieldsValid();
+    for (size_t j = 0; j < mon_fields.size(); j++)
+    {
+      monitoring_case_msg.fields.push_back(mon_fields.at(j));
+      monitoring_case_msg.fields_valid.push_back(mon_fields_valid.at(j));
+    }
+    response->monitoring_cases.push_back(monitoring_case_msg);
+  }
+
+  return true;
+}
+
+
+} // namespace sick

--- a/src/sick_safetyscanners2_lifecycle_node.cpp
+++ b/src/sick_safetyscanners2_lifecycle_node.cpp
@@ -1,0 +1,59 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+
+/*!
+*  Copyright (C) 2020, SICK AG, Waldkirch
+*  Copyright (C) 2020, FZI Forschungszentrum Informatik, Karlsruhe, Germany
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!
+ * \file sick_safetyscanners2_lifecycle_node.cpp
+ *
+ * \authors Soma gallai<soma.gallai@cm-robotics.com>  Erwin Lejeune <erwin.lejeune@cm-robotics.com>
+ * \date    2021-05-27
+ */
+//----------------------------------------------------------------------
+
+#include <sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <cstdio>
+
+int main(int argc, char** argv)
+{
+  (void)argc;
+  (void)argv;
+
+
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exe;
+  std::shared_ptr<sick::SickSafetyscannersLifeCycle> nh_ =
+  std::make_shared<sick::SickSafetyscannersLifeCycle>("SickSafetyscannersLifecycle");
+
+  exe.add_node(nh_->get_node_base_interface());
+  exe.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Solves #9 

Side note: we had issues with the sick scanner node crashing with an error -11 and reported it on issue #8. This is solved when using a lifecycle node where we call configure then activate using `ros2 lifecycle set /name_of_the_node configure && ros2 lifecycle set /name_of_the_node activate` or using navigation2's lifecycle manager node.