### PR TITLE
[feature] Adding service to retrieve config metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,51 +36,73 @@ set(dependencies
   sick_safetyscanners2_interfaces
 )
 
+# Component
+
 add_library(sick_safetyscanners2_component SHARED
   src/SickSafetyscannersRos2.cpp
   src/utils/MessageCreator.cpp)
 
+target_include_directories(sick_safetyscanners2_component PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
 ament_target_dependencies(sick_safetyscanners2_component ${dependencies})
+
+target_link_libraries(sick_safetyscanners2_component
+  sick_safetyscanners_base::sick_safetyscanners_base
+  ${Boost_LIBRARIES})
+
+rclcpp_components_register_nodes(sick_safetyscanners2_component "sick::SickSafetyscannersRos2")
+
+install(TARGETS sick_safetyscanners2_component EXPORT sick_safetyscanners2_component)
+
+# Executable
 
 add_executable(sick_safetyscanners2_node 
   src/sick_safetyscanners2_node.cpp)
 
 target_link_libraries(sick_safetyscanners2_node sick_safetyscanners2_component)
 
-target_include_directories(sick_safetyscanners2_component PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-
-# Manually register the component
-rclcpp_components_register_nodes(sick_safetyscanners2_component "sick::SickSafetyscannersRos2")
-
-  add_executable(sick_safetyscanners2_lifecycle_node 
-  src/sick_safetyscanners2_lifecycle_node.cpp
-  src/SickSafetyscannersLifeCycle.cpp
-  src/utils/MessageCreator.cpp)
-
-target_link_libraries(sick_safetyscanners2_lifecycle_node 
-  sick_safetyscanners_base::sick_safetyscanners_base
-  ${Boost_LIBRARIES})
-
-ament_target_dependencies(sick_safetyscanners2_lifecycle_node ${dependencies})
-
-target_include_directories(sick_safetyscanners2_lifecycle_node PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-
-install(DIRECTORY
-launch
-DESTINATION share/${PROJECT_NAME}/
-)
-
 install(TARGETS sick_safetyscanners2_node
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
 
+# Lifecycle component
+
+add_library(sick_safetyscanners2_lifecycle_component SHARED
+  src/SickSafetyscannersLifeCycle.cpp
+  src/utils/MessageCreator.cpp)
+
+target_include_directories(sick_safetyscanners2_lifecycle_component PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+ament_target_dependencies(sick_safetyscanners2_lifecycle_component ${dependencies})
+
+target_link_libraries(sick_safetyscanners2_lifecycle_component
+  sick_safetyscanners_base::sick_safetyscanners_base
+  ${Boost_LIBRARIES})
+
+rclcpp_components_register_nodes(sick_safetyscanners2_lifecycle_component "sick::SickSafetyscannersLifeCycle")
+
+install(TARGETS sick_safetyscanners2_lifecycle_component EXPORT sick_safetyscanners2_lifecycle_component)
+
+# Lifecycle Executable
+
+add_executable(sick_safetyscanners2_lifecycle_node
+  src/sick_safetyscanners2_lifecycle_node.cpp)
+
+target_link_libraries(sick_safetyscanners2_lifecycle_node
+  sick_safetyscanners2_lifecycle_component)
+
 install(TARGETS sick_safetyscanners2_lifecycle_node
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,32 +22,37 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(sick_safetyscanners_base REQUIRED)
 find_package(sick_safetyscanners2_interfaces REQUIRED)
 
 set(dependencies
   rclcpp
-  rclcpp_lifecycle 
-  lifecycle_msgs 
+  rclcpp_lifecycle
+  lifecycle_msgs
   sensor_msgs
+  rclcpp_components
   sick_safetyscanners_base
   sick_safetyscanners2_interfaces
-  )
+)
 
-add_executable(sick_safetyscanners2_node 
-  src/sick_safetyscanners2_node.cpp
+add_library(sick_safetyscanners2_component SHARED
   src/SickSafetyscannersRos2.cpp
   src/utils/MessageCreator.cpp)
 
-target_link_libraries(sick_safetyscanners2_node 
-  sick_safetyscanners_base::sick_safetyscanners_base
-  ${Boost_LIBRARIES})
+ament_target_dependencies(sick_safetyscanners2_component ${dependencies})
 
-ament_target_dependencies(sick_safetyscanners2_node ${dependencies})
+add_executable(sick_safetyscanners2_node 
+  src/sick_safetyscanners2_node.cpp)
 
-target_include_directories(sick_safetyscanners2_node PUBLIC
+target_link_libraries(sick_safetyscanners2_node sick_safetyscanners2_component)
+
+target_include_directories(sick_safetyscanners2_component PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+
+# Manually register the component
+rclcpp_components_register_nodes(sick_safetyscanners2_component "sick::SickSafetyscannersRos2")
 
   add_executable(sick_safetyscanners2_lifecycle_node 
   src/sick_safetyscanners2_lifecycle_node.cpp

--- a/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
@@ -42,6 +42,8 @@
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
 #include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
+#include <sick_safetyscanners2_interfaces/srv/application_name.hpp>
+#include <sick_safetyscanners2_interfaces/srv/type_code.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -66,6 +68,8 @@ class SickSafetyscannersLifeCycle : public rclcpp_lifecycle::LifecycleNode
 
 using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
 using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+using ApplicationName = sick_safetyscanners2_interfaces::srv::ApplicationName;
+using TypeCode = sick_safetyscanners2_interfaces::srv::TypeCode;
 
 public:
   /*!
@@ -100,6 +104,8 @@ private:
   // Services
   rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
   rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ApplicationName>::SharedPtr m_application_name_service;
+  rclcpp::Service<TypeCode>::SharedPtr m_type_code_service;
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
   rcl_interfaces::msg::SetParametersResult
@@ -144,6 +150,16 @@ private:
   bool getConfigMetadata(
     const std::shared_ptr<ConfigMetadata::Request> request,
     std::shared_ptr<ConfigMetadata::Response> response);
+
+  // Callback function to retrieve application name
+  bool getApplicationName(
+    const std::shared_ptr<ApplicationName::Request> request,
+    std::shared_ptr<ApplicationName::Response> response);
+    
+  // Callback function to retrieve type code
+  bool getTypeCode(
+    const std::shared_ptr<TypeCode::Request> request,
+    std::shared_ptr<TypeCode::Response> response);
 
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(

--- a/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
@@ -41,6 +41,7 @@
 
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
+#include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -62,6 +63,10 @@ namespace sick {
 
 class SickSafetyscannersLifeCycle : public rclcpp_lifecycle::LifecycleNode
 {
+
+using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
+using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+
 public:
   /*!
    * \brief Constructor of the ROS2 Node handling the Communication of the Sick Safetyscanner
@@ -93,7 +98,8 @@ private:
     sick_safetyscanners2_interfaces::msg::RawMicroScanData>::SharedPtr m_raw_data_publisher;
 
   // Services
-  rclcpp::Service<sick_safetyscanners2_interfaces::srv::FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
+  rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
   rcl_interfaces::msg::SetParametersResult
@@ -134,10 +140,15 @@ private:
   // Callback function passed to the device for handling the received packages
   void receiveUDPPaket(const sick::datastructure::Data& data);
 
+  // Callback function to retrieve configuration metadata
+  bool getConfigMetadata(
+    const std::shared_ptr<ConfigMetadata::Request> request,
+    std::shared_ptr<ConfigMetadata::Response> response);
+
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(
-    const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,
-    std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Response> response);
+    const std::shared_ptr<FieldData::Request> request,
+    std::shared_ptr<FieldData::Response> response);
   void readPersistentConfig();
   void readTypeCodeSettings();
 };

--- a/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
@@ -76,8 +76,7 @@ public:
    * \brief Constructor of the ROS2 Node handling the Communication of the Sick Safetyscanner
    */
 
-  explicit SickSafetyscannersLifeCycle(const std::string& node_name,
-                                       bool intra_process_comms = false);
+  explicit SickSafetyscannersLifeCycle(const rclcpp::NodeOptions& options);
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State&);

--- a/include/sick_safetyscanners2/SickSafetyscannersRos2.h
+++ b/include/sick_safetyscanners2/SickSafetyscannersRos2.h
@@ -68,7 +68,7 @@ public:
   /*!
    * \brief Constructor of the ROS2 Node handling the Communication of the Sick Safetyscanner
    */
-  SickSafetyscannersRos2();
+  SickSafetyscannersRos2(const rclcpp::NodeOptions& options);
 
 private:
   // Publishers

--- a/include/sick_safetyscanners2/SickSafetyscannersRos2.h
+++ b/include/sick_safetyscanners2/SickSafetyscannersRos2.h
@@ -41,6 +41,7 @@
 
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
+#include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -55,6 +56,10 @@ namespace sick {
 
 class SickSafetyscannersRos2 : public rclcpp::Node
 {
+
+using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
+using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+
 public:
   /*!
    * \brief Constructor of the ROS2 Node handling the Communication of the Sick Safetyscanner
@@ -72,7 +77,8 @@ private:
     m_raw_data_publisher;
 
   // Services
-  rclcpp::Service<sick_safetyscanners2_interfaces::srv::FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
+  rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
 
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
@@ -114,10 +120,15 @@ private:
   // Callback function passed to the device for handling the received packages
   void receiveUDPPaket(const sick::datastructure::Data& data);
 
+  // Callback function to retrieve configuration metadata
+  bool getConfigMetadata(
+    const std::shared_ptr<ConfigMetadata::Request> request,
+    std::shared_ptr<ConfigMetadata::Response> response);
+
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(
-    const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,
-    std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Response> response);
+    const std::shared_ptr<FieldData::Request> request,
+    std::shared_ptr<FieldData::Response> response);
   void readPersistentConfig();
   void readTypeCodeSettings();
 };

--- a/include/sick_safetyscanners2/SickSafetyscannersRos2.h
+++ b/include/sick_safetyscanners2/SickSafetyscannersRos2.h
@@ -42,6 +42,8 @@
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
 #include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
+#include <sick_safetyscanners2_interfaces/srv/application_name.hpp>
+#include <sick_safetyscanners2_interfaces/srv/type_code.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -59,6 +61,8 @@ class SickSafetyscannersRos2 : public rclcpp::Node
 
 using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
 using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+using ApplicationName = sick_safetyscanners2_interfaces::srv::ApplicationName;
+using TypeCode = sick_safetyscanners2_interfaces::srv::TypeCode;
 
 public:
   /*!
@@ -79,6 +83,9 @@ private:
   // Services
   rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
   rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ApplicationName>::SharedPtr m_application_name_service;
+  rclcpp::Service<TypeCode>::SharedPtr m_type_code_service;
+
 
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
@@ -124,6 +131,16 @@ private:
   bool getConfigMetadata(
     const std::shared_ptr<ConfigMetadata::Request> request,
     std::shared_ptr<ConfigMetadata::Response> response);
+
+  // Callback function to retrieve application name
+  bool getApplicationName(
+    const std::shared_ptr<ApplicationName::Request> request,
+    std::shared_ptr<ApplicationName::Response> response);
+    
+  // Callback function to retrieve type code
+  bool getTypeCode(
+    const std::shared_ptr<TypeCode::Request> request,
+    std::shared_ptr<TypeCode::Response> response);
 
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>sick_safetyscanners_base</depend>
   <depend>sick_safetyscanners2_interfaces</depend>
+  <depend>rclcpp_components</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -34,13 +34,13 @@
 
 #include <sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp>
 
+#include "rclcpp_components/register_node_macro.hpp"
+
 namespace sick {
 
 
-SickSafetyscannersLifeCycle::SickSafetyscannersLifeCycle(const std::string& node_name,
-                                                         bool intra_process_comms)
-  : rclcpp_lifecycle::LifecycleNode(
-      node_name, rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms))
+SickSafetyscannersLifeCycle::SickSafetyscannersLifeCycle(const rclcpp::NodeOptions& options)
+  : rclcpp_lifecycle::LifecycleNode("SickSafetyscannersLifecycle", options)
   , m_time_offset(0.0)
   , m_range_min(0.0)
   , m_range_max(0.0)
@@ -609,3 +609,5 @@ bool SickSafetyscannersLifeCycle::getTypeCode(
 
 
 } // namespace sick
+
+RCLCPP_COMPONENTS_REGISTER_NODE(sick::SickSafetyscannersLifeCycle)

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -87,6 +87,14 @@ SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State&)
               this,
               std::placeholders::_1,
               std::placeholders::_2));
+  m_application_name_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ApplicationName>("application_name",
+    std::bind(&SickSafetyscannersLifeCycle::getApplicationName,
+      this, std::placeholders::_1, std::placeholders::_2));
+  m_type_code_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::TypeCode>("type_code",
+    std::bind(&SickSafetyscannersLifeCycle::getTypeCode,
+      this, std::placeholders::_1, std::placeholders::_2));
 
 
   // Bind callback
@@ -560,6 +568,41 @@ bool SickSafetyscannersLifeCycle::getFieldData(
     response->monitoring_cases.push_back(monitoring_case_msg);
   }
 
+  return true;
+}
+
+bool SickSafetyscannersLifeCycle::getApplicationName(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto app_name = sick::datastructure::ApplicationName();
+  m_device->requestApplicationName(app_name);
+  response->version_c_version = app_name.getVersionCVersion();
+  response->major_version_number = app_name.getVersionMajorVersionNumber();
+  response->minor_version_number = app_name.getVersionMinorVersionNumber();
+  response->release_version_number = app_name.getVersionReleaseNumber();
+  response->name_length = app_name.getNameLength();
+  response->application_name = app_name.getApplicationName();
+  
+  return true;
+}
+
+bool SickSafetyscannersLifeCycle::getTypeCode(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto type_code = sick::datastructure::TypeCode();
+  m_device->requestTypeCode(type_code);
+  response->type_code = type_code.getTypeCode();
+  response->interface_type = type_code.getInterfaceType();
+  response->max_range = type_code.getMaxRange();  
+  
   return true;
 }
 

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -77,6 +77,10 @@ SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State&)
   m_raw_data_publisher =
     this->create_publisher<sick_safetyscanners2_interfaces::msg::RawMicroScanData>("raw_data", 1);
 
+  m_config_metadata_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ConfigMetadata>("config_metadata",
+    std::bind(&SickSafetyscannersLifeCycle::getConfigMetadata,
+      this, std::placeholders::_1, std::placeholders::_2));
   m_field_data_service = this->create_service<sick_safetyscanners2_interfaces::srv::FieldData>(
     "field_data",
     std::bind(&SickSafetyscannersLifeCycle::getFieldData,
@@ -481,6 +485,28 @@ void SickSafetyscannersLifeCycle::receiveUDPPaket(const sick::datastructure::Dat
   m_raw_data_publisher->publish(raw_msg);
 }
 
+bool SickSafetyscannersLifeCycle::getConfigMetadata(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ConfigMetadata::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ConfigMetadata::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto metadata = sick::datastructure::ConfigMetadata();
+  m_device->requestConfigMetadata(metadata);
+  response->version_c_version = metadata.getVersionCVersion();
+  response->major_version_number = metadata.getVersionMajorVersionNumber();
+  response->minor_version_number = metadata.getVersionMinorVersionNumber();
+  response->release_version_number = metadata.getVersionReleaseNumber();
+  response->modification_time_date = metadata.getModificationTimeDate();
+  response->modification_time_time = metadata.getModificationTimeTime();
+  response->transfer_time_date = metadata.getTransferTimeDate();
+  response->transfer_time_time = metadata.getTransferTimeTime();
+  response->app_checksum = metadata.getAppChecksum();
+  response->overall_checksum = metadata.getOverallChecksum();
+  response->integrity_hash = metadata.getIntegrityHash();
+  return true;
+}
 
 bool SickSafetyscannersLifeCycle::getFieldData(
   const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -134,14 +134,15 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 SickSafetyscannersLifeCycle::on_activate(const rclcpp_lifecycle::State&)
 {
   RCLCPP_INFO(this->get_logger(), "on_activate()...");
-  // Start async receiving and processing of sensor data
-  m_device->run();
-  m_device->changeSensorSettings(m_communications_settings);
 
   m_laser_scan_publisher->on_activate();
   m_extended_laser_scan_publisher->on_activate();
   m_output_paths_publisher->on_activate();
   m_raw_data_publisher->on_activate();
+
+  // Start async receiving and processing of sensor data
+  m_device->run();
+  m_device->changeSensorSettings(m_communications_settings);
 
   RCLCPP_INFO(this->get_logger(), "Node activated, device is running...");
 

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -33,12 +33,13 @@
 //----------------------------------------------------------------------
 
 #include <sick_safetyscanners2/SickSafetyscannersRos2.h>
+
 #include "rclcpp_components/register_node_macro.hpp"
 
 namespace sick {
 
-SickSafetyscannersRos2::SickSafetyscannersRos2()
-  : Node("SickSafetyscannersRos2")
+SickSafetyscannersRos2::SickSafetyscannersRos2(const rclcpp::NodeOptions& options)
+  : Node("SickSafetyscannersRos2", options)
   , m_time_offset(0.0)
   , m_range_min(0.0)
   , m_range_max(0.0)

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -68,6 +68,10 @@ SickSafetyscannersRos2::SickSafetyscannersRos2()
   m_raw_data_publisher =
     this->create_publisher<sick_safetyscanners2_interfaces::msg::RawMicroScanData>("raw_data", 1);
 
+  m_config_metadata_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ConfigMetadata>("config_metadata",
+    std::bind(&SickSafetyscannersRos2::getConfigMetadata,
+      this, std::placeholders::_1, std::placeholders::_2));
   m_field_data_service = this->create_service<sick_safetyscanners2_interfaces::srv::FieldData>(
     "field_data",
     std::bind(
@@ -418,6 +422,28 @@ void SickSafetyscannersRos2::receiveUDPPaket(const sick::datastructure::Data& da
   m_raw_data_publisher->publish(raw_msg);
 }
 
+bool SickSafetyscannersRos2::getConfigMetadata(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ConfigMetadata::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ConfigMetadata::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto metadata = sick::datastructure::ConfigMetadata();
+  m_device->requestConfigMetadata(metadata);
+  response->version_c_version = metadata.getVersionCVersion();
+  response->major_version_number = metadata.getVersionMajorVersionNumber();
+  response->minor_version_number = metadata.getVersionMinorVersionNumber();
+  response->release_version_number = metadata.getVersionReleaseNumber();
+  response->modification_time_date = metadata.getModificationTimeDate();
+  response->modification_time_time = metadata.getModificationTimeTime();
+  response->transfer_time_date = metadata.getTransferTimeDate();
+  response->transfer_time_time = metadata.getTransferTimeTime();
+  response->app_checksum = metadata.getAppChecksum();
+  response->overall_checksum = metadata.getOverallChecksum();
+  response->integrity_hash = metadata.getIntegrityHash();
+  return true;
+}
 
 bool SickSafetyscannersRos2::getFieldData(
   const std::shared_ptr<sick_safetyscanners2_interfaces::srv::FieldData::Request> request,

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -76,6 +76,14 @@ SickSafetyscannersRos2::SickSafetyscannersRos2()
     "field_data",
     std::bind(
       &SickSafetyscannersRos2::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
+  m_application_name_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ApplicationName>("application_name",
+    std::bind(&SickSafetyscannersRos2::getApplicationName,
+      this, std::placeholders::_1, std::placeholders::_2));
+  m_type_code_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::TypeCode>("type_code",
+    std::bind(&SickSafetyscannersRos2::getTypeCode,
+      this, std::placeholders::_1, std::placeholders::_2));
 
   // Bind callback
   std::function<void(const sick::datastructure::Data&)> callback =
@@ -497,6 +505,41 @@ bool SickSafetyscannersRos2::getFieldData(
     response->monitoring_cases.push_back(monitoring_case_msg);
   }
 
+  return true;
+}
+
+bool SickSafetyscannersRos2::getApplicationName(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto app_name = sick::datastructure::ApplicationName();
+  m_device->requestApplicationName(app_name);
+  response->version_c_version = app_name.getVersionCVersion();
+  response->major_version_number = app_name.getVersionMajorVersionNumber();
+  response->minor_version_number = app_name.getVersionMinorVersionNumber();
+  response->release_version_number = app_name.getVersionReleaseNumber();
+  response->name_length = app_name.getNameLength();
+  response->application_name = app_name.getApplicationName();
+  
+  return true;
+}
+
+bool SickSafetyscannersRos2::getTypeCode(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto type_code = sick::datastructure::TypeCode();
+  m_device->requestTypeCode(type_code);
+  response->type_code = type_code.getTypeCode();
+  response->interface_type = type_code.getInterfaceType();
+  response->max_range = type_code.getMaxRange();  
+  
   return true;
 }
 

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -33,6 +33,7 @@
 //----------------------------------------------------------------------
 
 #include <sick_safetyscanners2/SickSafetyscannersRos2.h>
+#include "rclcpp_components/register_node_macro.hpp"
 
 namespace sick {
 
@@ -545,3 +546,4 @@ bool SickSafetyscannersRos2::getTypeCode(
 
 
 } // namespace sick
+RCLCPP_COMPONENTS_REGISTER_NODE(sick::SickSafetyscannersRos2)

--- a/src/sick_safetyscanners2_lifecycle_node.cpp
+++ b/src/sick_safetyscanners2_lifecycle_node.cpp
@@ -43,13 +43,12 @@ int main(int argc, char** argv)
   (void)argc;
   (void)argv;
 
-
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor exe;
   std::shared_ptr<sick::SickSafetyscannersLifeCycle> nh_ =
-    std::make_shared<sick::SickSafetyscannersLifeCycle>("SickSafetyscannersLifecycle");
+    std::make_shared<sick::SickSafetyscannersLifeCycle>(rclcpp::NodeOptions());
 
   exe.add_node(nh_->get_node_base_interface());
   exe.spin();

--- a/src/sick_safetyscanners2_node.cpp
+++ b/src/sick_safetyscanners2_node.cpp
@@ -45,9 +45,8 @@ int main(int argc, char** argv)
   (void)argc;
   (void)argv;
 
-
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<sick::SickSafetyscannersRos2>());
+  rclcpp::spin(std::make_shared<sick::SickSafetyscannersRos2>(rclcpp::NodeOptions()));
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Depends on https://github.com/SICKAG/sick_safetyscanners2_interfaces/pull/1

Adding a service to retrieve the configuration metadata from the scanners. In our use-case it is in particoular important to retrieve the checksum of the flashed configuration.

Example of output:

```
ros2 service call /robot_interface/micro_scan_front/config_metadata sick_safetyscanners2_interfaces/srv/ConfigMetadata "{}"
requester: making request: sick_safetyscanners2_interfaces.srv.ConfigMetadata_Request()

response:
sick_safetyscanners2_interfaces.srv.ConfigMetadata_Response(version_c_version='R', major_version_number=1, minor_version_number=1, release_version_number=0, modification_time_date=18421, modification_time_time=51078517, transfer_time_date=18421, transfer_time_time=51106684, app_checksum=1062728593, overall_checksum=272674095 , integrity_hash=[3011455438, 1669370804, 3192696433, 1845893173])
```