### PR TITLE
Add frequency diagnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(Boost REQUIRED COMPONENTS chrono)
+find_package(diagnostic_updater REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
@@ -26,6 +27,7 @@ find_package(sick_safetyscanners_base REQUIRED)
 find_package(sick_safetyscanners2_interfaces REQUIRED)
 
 set(dependencies
+  diagnostic_updater
   rclcpp
   rclcpp_lifecycle 
   lifecycle_msgs 

--- a/include/sick_safetyscanners2/SickSafetyscannersRos2.h
+++ b/include/sick_safetyscanners2/SickSafetyscannersRos2.h
@@ -46,6 +46,8 @@
 #include <sick_safetyscanners2/utils/Conversions.h>
 #include <sick_safetyscanners2/utils/MessageCreator.h>
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 
@@ -62,6 +64,8 @@ public:
   SickSafetyscannersRos2();
 
 private:
+  using DiagnosedLaserScanPublisher = diagnostic_updater::DiagnosedPublisher<sensor_msgs::msg::LaserScan>;
+
   // Publishers
   rclcpp::Publisher<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>::SharedPtr
     m_extended_laser_scan_publisher;
@@ -70,6 +74,10 @@ private:
     m_output_paths_publisher;
   rclcpp::Publisher<sick_safetyscanners2_interfaces::msg::RawMicroScanData>::SharedPtr
     m_raw_data_publisher;
+
+  // Diagnostics
+  diagnostic_updater::Updater m_diagnostic_updater;
+  std::shared_ptr<DiagnosedLaserScanPublisher> m_diagnosed_laser_scan_publisher;
 
   // Services
   rclcpp::Service<sick_safetyscanners2_interfaces::srv::FieldData>::SharedPtr m_field_data_service;
@@ -103,7 +111,6 @@ private:
   float m_angle_offset;
   bool m_use_pers_conf;
 
-  // TODO diagnostics?
   // TODO dynamic reconfigure?
 
   // Methods for ROS2 parameter handling

--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,9 @@
   <license>ALv2</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <depend>boost</depend>
+  <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -207,7 +207,6 @@ void SickSafetyscannersRos2::load_parameters()
   this->get_parameter<int>("skip", skip);
   RCLCPP_INFO(node_logger, "skip: %i", skip);
   m_communications_settings.publishing_frequency = skipToPublishFrequency(skip);
-  m_expected_frequency = static_cast<double>(m_communications_settings.publishing_frequency) / 1000.0;
 
   float angle_start;
   this->get_parameter<float>("angle_start", angle_start);


### PR DESCRIPTION
I was recently using a Sick scanner and noticed that the ROS2 interface does not contain any diagnostics. I started with a basic frequency diagnostic ( basically a port of SICKAG/sick_safetyscanners@3ba34888784f8b8c541c8f0813ddebc7a95cec17 ), but I can extend it as needed!

Please let me know what you think, I checked functionality with a SICK nanoscan.
