### PR TITLE
Replace deprecated from_string with make_address_v4

### DIFF
--- a/include/sick_safetyscanners2/SickSafetyscanners.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscanners.hpp
@@ -148,20 +148,20 @@ public:
     std::string sensor_ip;
     node.template get_parameter<std::string>("sensor_ip", sensor_ip);
     RCLCPP_INFO(getLogger(), "sensor_ip: %s", sensor_ip.c_str());
-    m_config.m_sensor_ip = boost::asio::ip::address_v4::from_string(sensor_ip);
+    m_config.m_sensor_ip = boost::asio::ip::make_address_v4(sensor_ip);
 
     std::string interface_ip;
     node.template get_parameter<std::string>("interface_ip", interface_ip);
     RCLCPP_INFO(getLogger(), "interface_ip: %s", interface_ip.c_str());
     m_config.m_interface_ip =
-        boost::asio::ip::address_v4::from_string(interface_ip);
+        boost::asio::ip::make_address_v4(interface_ip);
 
     std::string host_ip;
     node.template get_parameter<std::string>("host_ip", host_ip);
     RCLCPP_INFO(getLogger(), "host_ip: %s", host_ip.c_str());
     // TODO check if valid IP?
     m_config.m_communications_settings.host_ip =
-        boost::asio::ip::address_v4::from_string(host_ip);
+        boost::asio::ip::make_address_v4(host_ip);
 
     int host_udp_port;
     node.template get_parameter<int>("host_udp_port", host_udp_port);

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -54,7 +54,7 @@ rcl_interfaces::msg::SetParametersResult SickSafetyscanners::parametersCallback(
       m_config.m_frame_id = param.value_to_string();
     } else if (param.get_name() == "host_ip") {
       m_config.m_communications_settings.host_ip =
-          boost::asio::ip::address_v4::from_string(param.value_to_string());
+          boost::asio::ip::make_address_v4(param.value_to_string());
       update_sensor_config = true;
     } else if (param.get_name() == "host_udp_port") {
       m_config.m_communications_settings.host_udp_port = param.as_int();


### PR DESCRIPTION
### Description

Replace deprecated `boost::asio::ip::address_v4::from_string()` calls with the modern
`boost::asio::ip::make_address_v4()` free function for IPv4 address parsing.

**Why this change is needed:**
- `from_string()` was deprecated in Boost 1.66
- Eliminates deprecation warnings during compilation
- Ensures compatibility with newer Boost versions (i.e. 1.87+)

**Changes:**
- Updated 3 occurrences in `SickSafetyscanners.hpp` (sensor_ip, interface_ip, host_ip parsing)
- Updated 1 occurrence in `SickSafetyscanners.cpp` (dynamic host_ip parameter callback)

### Test Case

Steps to verify the changes:
1. Build the package with a recent Boost version (≥1.66)
2. Verify no deprecation warnings related to `from_string()` appear
3. Launch the node with valid IP parameters
4. Dynamically update the `host_ip` parameter at runtime

Expected result: Node builds without deprecation warnings and correctly parses all IP addresses
