### PR TITLE
Replace ament_target_libraries with target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,13 @@ find_package(sick_safetyscanners_base REQUIRED)
 find_package(sick_safetyscanners2_interfaces REQUIRED)
 
 set(dependencies
-        diagnostic_updater
-        rclcpp
-        rclcpp_lifecycle
-        lifecycle_msgs
-        sensor_msgs
-        sick_safetyscanners_base
-        sick_safetyscanners2_interfaces
+        diagnostic_updater::diagnostic_updater
+        rclcpp::rclcpp
+        rclcpp_lifecycle::rclcpp_lifecycle
+        ${lifecycle_msgs_TARGETS}
+        ${sensor_msgs}
+        sick_safetyscanners_base::sick_safetyscanners_base
+        ${sick_safetyscanners2_interfaces_TARGETS}
 )
 
 add_executable(sick_safetyscanners2_node
@@ -46,7 +46,7 @@ target_link_libraries(sick_safetyscanners2_node
         sick_safetyscanners_base::sick_safetyscanners_base
         ${Boost_LIBRARIES})
 
-ament_target_dependencies(sick_safetyscanners2_node ${dependencies})
+target_link_libraries(sick_safetyscanners2_node ${dependencies})
 
 target_include_directories(sick_safetyscanners2_node PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -62,7 +62,7 @@ target_link_libraries(sick_safetyscanners2_lifecycle_node
         sick_safetyscanners_base::sick_safetyscanners_base
         ${Boost_LIBRARIES})
 
-ament_target_dependencies(sick_safetyscanners2_lifecycle_node ${dependencies})
+target_link_libraries(sick_safetyscanners2_lifecycle_node ${dependencies})
 
 target_include_directories(sick_safetyscanners2_lifecycle_node PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Build is broken  https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__sick_safetyscanners2__ubuntu_noble_amd64__binary/

It requires a release here too https://github.com/SICKAG/sick_safetyscanners2_interfaces/issues/5